### PR TITLE
Implement basic auth and project sharing

### DIFF
--- a/backend/api/open_ai.py
+++ b/backend/api/open_ai.py
@@ -2,18 +2,18 @@ import os
 from openai import OpenAI
 from dotenv import load_dotenv
 from pathlib import Path
+
+# Load environment variables from project root .env
 load_dotenv(dotenv_path=Path(__file__).resolve().parents[2] / ".env")
 
+# Initialize OpenAI client
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-def query(prompt):
-    # Send query -- How many r's in the word strawberry?
 
+def query(prompt: str) -> str:
+    """Send a prompt to OpenAI and return the response text."""
     response = client.chat.completions.create(
         model="gpt-4o",
-        messages = [
-            {"role": "user", "content": prompt}
-        ]
+        messages=[{"role": "user", "content": prompt}],
     )
-
     return response.choices[0].message.content.strip()

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,9 +2,11 @@ from flask import Flask, request, jsonify
 import os
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
+from werkzeug.security import generate_password_hash, check_password_hash
 from api.open_ai import query as openai_query
 import json
 from pathlib import Path
+import uuid
 
 app = Flask(__name__)
 CORS(app)
@@ -21,11 +23,16 @@ app.config['MAX_CONTENT_LENGTH'] = MAX_FILE_SIZE
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 # Store projects and their files in memory (in production, use a database)
-projects_data = {
-    "Alpha": {"files": []},
-    "Beta": {"files": []},
-    "Gamma": {"files": []}
-}
+projects_data = {}
+
+# In-memory user store and active sessions.
+# users = {
+#     "alice": {"password": "hash", "projects": {"Alpha"}}
+# }
+users = {}
+
+# sessions = {token: username}
+sessions = {}
 
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
@@ -49,23 +56,76 @@ def read_file_content(filepath):
     except Exception as e:
         return f"[Error reading file: {str(e)}]"
 
+
+def get_current_user():
+    """Return the username associated with the bearer token."""
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1]
+        return sessions.get(token)
+    return None
+
 @app.route('/')
 def index():
     return jsonify(message='MxChat is Running...')
 
+
+@app.route('/register', methods=['POST'])
+def register():
+    """Create a new user account."""
+    data = request.get_json()
+    username = data.get('username', '').strip()
+    password = data.get('password', '')
+
+    if not username or not password:
+        return jsonify(error='Username and password required'), 400
+    if username in users:
+        return jsonify(error='User already exists'), 400
+
+    users[username] = {
+        'password': generate_password_hash(password),
+        'projects': set()
+    }
+    return jsonify(status='ok')
+
+
+@app.route('/login', methods=['POST'])
+def login():
+    """Authenticate a user and return a session token."""
+    data = request.get_json()
+    username = data.get('username', '').strip()
+    password = data.get('password', '')
+
+    user = users.get(username)
+    if not user or not check_password_hash(user['password'], password):
+        return jsonify(error='Invalid credentials'), 401
+
+    token = str(uuid.uuid4())
+    sessions[token] = username
+    return jsonify(token=token)
+
 @app.route('/create_project', methods=['POST'])
 def create_project():
     try:
+        user = get_current_user()
+        if not user:
+            return jsonify(error='Unauthorized'), 401
+
         data = request.get_json()
         project_name = data.get("name", "Unnamed Project").strip()
-        
+
         if not project_name:
             return jsonify(error="Project name cannot be empty"), 400
-            
+
         if project_name in projects_data:
             return jsonify(error="Project already exists"), 400
-            
-        projects_data[project_name] = {"files": []}
+
+        projects_data[project_name] = {
+            "files": [],
+            "owner": user,
+            "shared_with": set(),
+        }
+        users[user]["projects"].add(project_name)
         return jsonify(status="ok", message=f"Created project: {project_name}")
     except Exception as e:
         return jsonify(error=str(e)), 500
@@ -73,22 +133,33 @@ def create_project():
 @app.route('/get_projects', methods=['GET'])
 def get_projects():
     try:
-        return jsonify(projects=list(projects_data.keys()))
+        user = get_current_user()
+        if not user:
+            return jsonify(error='Unauthorized'), 401
+
+        return jsonify(projects=list(users[user]['projects']))
     except Exception as e:
         return jsonify(error=str(e)), 500
 
 @app.route('/upload_file', methods=['POST'])
 def upload_file():
     try:
+        user = get_current_user()
+        if not user:
+            return jsonify(error='Unauthorized'), 401
+
         if 'file' not in request.files:
             return jsonify(error='No file provided'), 400
-            
+
         file = request.files['file']
         project_name = request.form.get('project')
-        
+
         if not project_name or project_name not in projects_data:
             return jsonify(error='Invalid project'), 400
-            
+
+        if projects_data[project_name].get('owner') != user:
+            return jsonify(error='Only the project owner can upload files'), 403
+
         if file.filename == '':
             return jsonify(error='No file selected'), 400
             
@@ -125,16 +196,56 @@ def upload_file():
 @app.route('/get_project_files/<project_name>', methods=['GET'])
 def get_project_files(project_name):
     try:
+        user = get_current_user()
+        if not user:
+            return jsonify(error='Unauthorized'), 401
+
         if project_name not in projects_data:
             return jsonify(error='Project not found'), 404
-            
-        return jsonify(files=projects_data[project_name]['files'])
+
+        project = projects_data[project_name]
+        if project.get('owner') != user and user not in project.get('shared_with', set()):
+            return jsonify(error='Access denied'), 403
+
+        return jsonify(files=project['files'])
+    except Exception as e:
+        return jsonify(error=str(e)), 500
+
+
+@app.route('/share_project', methods=['POST'])
+def share_project():
+    """Allow a project owner to share the project with another user."""
+    try:
+        user = get_current_user()
+        if not user:
+            return jsonify(error='Unauthorized'), 401
+
+        data = request.get_json()
+        project_name = data.get('project')
+        share_with = data.get('user')
+
+        if not project_name or project_name not in projects_data:
+            return jsonify(error='Project not found'), 404
+        if share_with not in users:
+            return jsonify(error='User not found'), 404
+
+        project = projects_data[project_name]
+        if project.get('owner') != user:
+            return jsonify(error='Only the owner can share this project'), 403
+
+        project['shared_with'].add(share_with)
+        users[share_with]['projects'].add(project_name)
+        return jsonify(status='ok')
     except Exception as e:
         return jsonify(error=str(e)), 500
 
 @app.route('/query', methods=['POST'])
 def query():
     try:
+        user = get_current_user()
+        if not user:
+            return jsonify(error='Unauthorized'), 401
+
         data = request.get_json()
         prompt = data.get("prompt", "").strip()
         project_name = data.get("project", "")
@@ -146,7 +257,10 @@ def query():
         # Build context from uploaded files if requested
         context = ""
         if include_files and project_name and project_name in projects_data:
-            files = projects_data[project_name]['files']
+            project = projects_data[project_name]
+            if project.get('owner') != user and user not in project.get('shared_with', set()):
+                return jsonify(error='Access denied'), 403
+            files = project['files']
             if files:
                 context = "\n\n=== UPLOADED FILES CONTEXT ===\n"
                 for file_info in files:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,20 +3,24 @@ import ProjectDashboard from './components/ProjectDashboard';
 import ChatInterface from './components/ChatInterface';
 import FileUpload from './components/FileUpload';
 import SharedQueries from './components/SharedQueries';
+import LoginForm from './components/LoginForm';
 
 function App() {
   const [currentProject, setCurrentProject] = useState(null);
+  const [loggedIn, setLoggedIn] = useState(!!localStorage.getItem('token'));
 
   return (
     <div style={{ padding: '2rem' }}>
       <h1>MxChat</h1>
-      {!currentProject ? (
+      {!loggedIn ? (
+        <LoginForm onLoggedIn={() => setLoggedIn(true)} />
+      ) : !currentProject ? (
         <ProjectDashboard onSelect={setCurrentProject} />
       ) : (
         <>
           <button onClick={() => setCurrentProject(null)}>← Back to Projects</button>
           <h2>Project: {currentProject}</h2>
-          <ChatInterface />
+          <ChatInterface project={currentProject} />
           <FileUpload />
           <SharedQueries />
         </>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,11 +2,28 @@ import axios from 'axios';
 
 const API_BASE = 'http://localhost:5000'; // Flask backend
 
+const authHeaders = () => ({
+  Authorization: `Bearer ${localStorage.getItem('token')}`,
+});
+
+export const register = (username, password) =>
+  axios.post(`${API_BASE}/register`, { username, password });
+
+export const login = (username, password) =>
+  axios.post(`${API_BASE}/login`, { username, password });
+
 export const createProject = (name) =>
-  axios.post(`${API_BASE}/create_project`, { name });
+  axios.post(`${API_BASE}/create_project`, { name }, { headers: authHeaders() });
 
 export const getProjects = () =>
-  axios.get(`${API_BASE}/get_projects`);
+  axios.get(`${API_BASE}/get_projects`, { headers: authHeaders() });
 
-export const sendQuery = (prompt) =>
-  axios.post(`${API_BASE}/query`, { prompt });
+export const shareProject = (project, user) =>
+  axios.post(`${API_BASE}/share_project`, { project, user }, { headers: authHeaders() });
+
+export const sendQuery = (prompt, project, includeFiles) =>
+  axios.post(
+    `${API_BASE}/query`,
+    { prompt, project, include_files: includeFiles },
+    { headers: authHeaders() }
+  );

--- a/frontend/src/components/ChatInterface.js
+++ b/frontend/src/components/ChatInterface.js
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import { sendQuery } from '../api';
 
-export default function ChatInterface() {
+export default function ChatInterface({ project }) {
   const [prompt, setPrompt] = useState('');
   const [response, setResponse] = useState('');
+  const [includeFiles, setIncludeFiles] = useState(false);
 
   const handleSend = async () => {
-    const res = await sendQuery(prompt);
-    setResponse(res.data);
+    const res = await sendQuery(prompt, project, includeFiles);
+    setResponse(res.data.response || res.data);
   };
 
   return (
@@ -21,6 +22,16 @@ export default function ChatInterface() {
         placeholder="Ask GPT something..."
       />
       <br />
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={includeFiles}
+            onChange={e => setIncludeFiles(e.target.checked)}
+          />
+          Include project files
+        </label>
+      </div>
       <button onClick={handleSend}>Send</button>
       <pre>{response}</pre>
     </div>

--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { login, register } from '../api';
+
+export default function LoginForm({ onLoggedIn }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isRegister, setIsRegister] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async () => {
+    try {
+      if (isRegister) {
+        await register(username, password);
+      }
+      const res = await login(username, password);
+      localStorage.setItem('token', res.data.token);
+      onLoggedIn();
+    } catch (e) {
+      setError('Authentication failed');
+    }
+  };
+
+  return (
+    <div>
+      <h2>{isRegister ? 'Register' : 'Login'}</h2>
+      <input
+        placeholder="Username"
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button onClick={handleSubmit}>{isRegister ? 'Register' : 'Login'}</button>
+      <button onClick={() => setIsRegister(prev => !prev)}>
+        {isRegister ? 'Have an account? Login' : 'Need an account? Register'}
+      </button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/ProjectDashboard.js
+++ b/frontend/src/components/ProjectDashboard.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { getProjects, createProject } from '../api';
+import { getProjects, createProject, shareProject } from '../api';
 
 export default function ProjectDashboard({ onSelect }) {
   const [projects, setProjects] = useState([]);
   const [name, setName] = useState('');
+  const [shareUser, setShareUser] = useState('');
 
   useEffect(() => {
     getProjects().then(res => {
@@ -18,11 +19,24 @@ export default function ProjectDashboard({ onSelect }) {
     });
   };
 
+  const handleShare = (p) => {
+    shareProject(p, shareUser).then(() => setShareUser(''));
+  };
+
   return (
     <div>
       <h2>Projects</h2>
       {projects.map(p => (
-        <button key={p} onClick={() => onSelect(p)}>{p}</button>
+        <div key={p} style={{ marginBottom: '0.5rem' }}>
+          <button onClick={() => onSelect(p)}>{p}</button>
+          <input
+            style={{ marginLeft: '0.5rem' }}
+            placeholder="Share with user"
+            value={shareUser}
+            onChange={e => setShareUser(e.target.value)}
+          />
+          <button onClick={() => handleShare(p)}>Share</button>
+        </div>
       ))}
       <input
         value={name}


### PR DESCRIPTION
## Summary
- fix truncated OpenAI client helper
- implement registration, login, and token auth for backend
- restrict project actions to authenticated users
- support sharing projects with other users
- add login UI and update API helpers in React frontend

## Testing
- `python -m py_compile backend/app.py backend/api/open_ai.py`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891ef6427c8324923669609b7bcb49